### PR TITLE
Reverse include slashes and change AMX assembly folder name

### DIFF
--- a/codbuf.inc
+++ b/codbuf.inc
@@ -19,6 +19,11 @@
 #tryinclude "..\amx_assembly\codescan"
 #tryinclude "..\amx\codescan"
 
+#tryinclude "amx_assembly/codescan"
+#tryinclude "amx/codescan"
+#tryinclude "../amx_assembly/codescan"
+#tryinclude "../amx/codescan"
+
 #if !defined CODESCAN_INC
 	#error The latest amx_assembly is required. Get it here: github.com/Zeex/amx_assembly
 #endif

--- a/codbuf.inc
+++ b/codbuf.inc
@@ -14,7 +14,14 @@
 	#error CODBUF_KB must be between 1 and 100
 #endif
 
-#include <amx\codescan>
+#tryinclude "amx_assembly\codescan"
+#tryinclude "amx\codescan"
+#tryinclude "..\amx_assembly\codescan"
+#tryinclude "..\amx\codescan"
+
+#if !defined CODESCAN_INC
+	#error The latest amx_assembly is required. Get it here: github.com/Zeex/amx_assembly
+#endif
 
 #define CBF(%1) %1
 

--- a/codbuf.inc
+++ b/codbuf.inc
@@ -14,7 +14,7 @@
 	#error CODBUF_KB must be between 1 and 100
 #endif
 
-#include <amx_assembly/codescan>
+#include <amx\codescan>
 
 #define CBF(%1) %1
 

--- a/observe.inc
+++ b/observe.inc
@@ -24,9 +24,25 @@
 #define _INC_OBSERVE
 
 #include <a_samp>
-#include <amx\codescan>
-#include <amx\asm>
-#include <amx\phys_memory>
+
+#tryinclude "amx_assembly\codescan"
+#tryinclude "amx\codescan"
+#tryinclude "..\amx_assembly\codescan"
+#tryinclude "..\amx\codescan"
+
+#tryinclude "amx_assembly\asm"
+#tryinclude "amx\asm"
+#tryinclude "..\amx_assembly\asm"
+#tryinclude "..\amx\asm"
+
+#tryinclude "amx_assembly\phys_memory"
+#tryinclude "amx\phys_memory"
+#tryinclude "..\amx_assembly\phys_memory"
+#tryinclude "..\amx\phys_memory"
+
+#if !defined CODESCAN_INC
+	#error The latest amx_assembly is required. Get it here: github.com/Zeex/amx_assembly
+#endif
 
 #if !defined OBSERVE_CODE_SIZE
 	#define OBSERVE_CODE_SIZE 20480

--- a/observe.inc
+++ b/observe.inc
@@ -24,9 +24,9 @@
 #define _INC_OBSERVE
 
 #include <a_samp>
-#include <amx_assembly/codescan>
-#include <amx_assembly/asm>
-#include <amx_assembly/phys_memory>
+#include <amx\codescan>
+#include <amx\asm>
+#include <amx\phys_memory>
 
 #if !defined OBSERVE_CODE_SIZE
 	#define OBSERVE_CODE_SIZE 20480
@@ -216,6 +216,7 @@ public ObModifyVar_FoundCallback(m[CodeScanner]) {
 	s_CodeOffset += ctx[AsmContext_buffer_offset];
 }
 
+forward ObHandleAsmError(ctx[AsmContext]);
 forward ObArrayScan_FoundCallback(m[CodeScanner]);
 
 #define ObserveArray(%1,%2) \

--- a/observe.inc
+++ b/observe.inc
@@ -30,15 +30,30 @@
 #tryinclude "..\amx_assembly\codescan"
 #tryinclude "..\amx\codescan"
 
+#tryinclude "amx_assembly/codescan"
+#tryinclude "amx/codescan"
+#tryinclude "../amx_assembly/codescan"
+#tryinclude "../amx/codescan"
+
 #tryinclude "amx_assembly\asm"
 #tryinclude "amx\asm"
 #tryinclude "..\amx_assembly\asm"
 #tryinclude "..\amx\asm"
 
+#tryinclude "amx_assembly/asm"
+#tryinclude "amx/asm"
+#tryinclude "../amx_assembly/asm"
+#tryinclude "../amx/asm"
+
 #tryinclude "amx_assembly\phys_memory"
 #tryinclude "amx\phys_memory"
 #tryinclude "..\amx_assembly\phys_memory"
 #tryinclude "..\amx\phys_memory"
+
+#tryinclude "amx_assembly/phys_memory"
+#tryinclude "amx/phys_memory"
+#tryinclude "../amx_assembly/phys_memory"
+#tryinclude "../amx/phys_memory"
 
 #if !defined CODESCAN_INC
 	#error The latest amx_assembly is required. Get it here: github.com/Zeex/amx_assembly


### PR DESCRIPTION
Since I and everyone else who has YSI has the AMX assembly package in a folder called specifically "amx" I changed the include names to that.
The slashes were giving me compile errors so I reversed them.

Oh, and there was also a forward missing. I feel like that was for some reason intentional (obviously not something you just forgot) so I just added it back.
